### PR TITLE
@types/k6 Fix runtime error when grcp Stream experimental

### DIFF
--- a/types/k6/experimental/grpc.d.ts
+++ b/types/k6/experimental/grpc.d.ts
@@ -81,22 +81,21 @@ declare namespace grpc {
      * StreamEvent describes the possible events that can be emitted
      * by a gRPC stream.
      */
-    enum StreamEvent {
+    type StreamEvent =
         /**
          * Event fired when data has been received from the server.
          */
-        Data = 'data',
+        | 'data'
 
         /**
          * Event fired when a stream has been closed due to an error.
          */
-        Error = 'error',
+        | 'error'
 
         /**
          * Event fired when the stream closes.
          */
-        End = 'end',
-    }
+        | 'end';
 
     /**
      * Stream allows you to use streaming RPCs.

--- a/types/k6/test/experimental/grpc.ts
+++ b/types/k6/test/experimental/grpc.ts
@@ -40,7 +40,7 @@ client.invoke('main.RouteGuide/UpdateFeature', req, params_with_string_timeout);
 
 const stream = new grpc.Stream(client, 'main.RouteGuide/GetFeature', params);
 
-stream.on(grpc.StreamEvent.Data, (data) => {
+stream.on('data', data => {
     data; // $ExpectType object | GrpcError | undefined
 });
 


### PR DESCRIPTION
If try to run a k6 script with the steam event types like:
```ts
import grpc from "k6/experimental/grpc";

const stream = new grpc.Stream(...);

stream.on(grpc.StreamEvent.Data, (d) => {
  console.log(JSON.stringify(d));
});
```
I am getting a runtime error `ERRO[0000] TypeError: Cannot read property 'Data' of undefined`. It looks like the StreamEvent enum is not defined. But, it works if we run it like:
```diff
import grpc from "k6/experimental/grpc";

const stream = new grpc.Stream(...);

-stream.on(grpc.StreamEvent.Data, (d) => {
+stream.on('data', (d) => {
  console.log(JSON.stringify(d));
});
```
So, changing `StreamEvent` from enum to union of string literal types works in runtime and enforce types.