### PR TITLE
Remove strict option from locator APIs

### DIFF
--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1644,32 +1644,32 @@ export interface Locator {
      * @param options Options to use.
      * @returns Promise which resolves when the element is successfully clicked.
      */
-    click(options?: MouseMoveOptions & MouseMultiClickOptions & StrictnessOptions): Promise<void>;
+    click(options?: MouseMoveOptions & MouseMultiClickOptions): Promise<void>;
 
     /**
      * Mouse double click on the chosen element.
      * @param options Options to use.
      */
-    dblclick(options?: MouseMoveOptions & MouseMultiClickOptions & StrictnessOptions): void;
+    dblclick(options?: MouseMoveOptions & MouseMultiClickOptions): void;
 
     /**
      * Use this method to select an `input type="checkbox"`.
      * @param options Options to use.
      */
-    check(options?: ElementClickOptions & StrictnessOptions): void;
+    check(options?: ElementClickOptions): void;
 
     /**
      * Use this method to unselect an `input type="checkbox"`.
      * @param options Options to use.
      */
-    uncheck(options?: ElementClickOptions & StrictnessOptions): void;
+    uncheck(options?: ElementClickOptions): void;
 
     /**
      * Checks to see if the `input type="checkbox"` is selected or not.
      * @param options Options to use.
      * @returns `true` if the element is checked, `false` otherwise.
      */
-    isChecked(options?: TimeoutOptions & StrictnessOptions): boolean;
+    isChecked(options?: TimeoutOptions): boolean;
 
     /**
      * Checks if the element is editable.
@@ -1683,14 +1683,14 @@ export interface Locator {
      * @param options Options to use.
      * @returns `true` if the element is enabled, `false` otherwise.
      */
-    isEnabled(options?: TimeoutOptions & StrictnessOptions): boolean;
+    isEnabled(options?: TimeoutOptions): boolean;
 
     /**
      * Checks if the element is `disabled`.
      * @param options Options to use.
      * @returns `true` if the element is disabled, `false` otherwise.
      */
-    isDisabled(options?: TimeoutOptions & StrictnessOptions): boolean;
+    isDisabled(options?: TimeoutOptions): boolean;
 
     /**
      * Checks if the element is `visible`.
@@ -1709,13 +1709,13 @@ export interface Locator {
      * @param value Value to fill for the `input` or `textarea` element.
      * @param options Options to use.
      */
-    fill(value: string, options?: ElementHandleOptions & StrictnessOptions): void;
+    fill(value: string, options?: ElementHandleOptions): void;
 
     /**
      * Focuses the element using locator's selector.
      * @param options Options to use.
      */
-    focus(options?: TimeoutOptions & StrictnessOptions): void;
+    focus(options?: TimeoutOptions): void;
 
     /**
      * Returns the element attribute value for the given attribute name.
@@ -1723,35 +1723,35 @@ export interface Locator {
      * @param options Options to use.
      * @returns Attribute value.
      */
-    getAttribute(name: string, options?: TimeoutOptions & StrictnessOptions): string | null;
+    getAttribute(name: string, options?: TimeoutOptions): string | null;
 
     /**
      * Returns the `element.innerHTML`.
      * @param options Options to use.
      * @returns Element's innerHTML.
      */
-    innerHTML(options?: TimeoutOptions & StrictnessOptions): string;
+    innerHTML(options?: TimeoutOptions): string;
 
     /**
      * Returns the `element.innerText`.
      * @param options Options to use.
      * @returns Element's innerText.
      */
-    innerText(options?: TimeoutOptions & StrictnessOptions): string;
+    innerText(options?: TimeoutOptions): string;
 
     /**
      * Returns the `element.textContent`.
      * @param options Options to use.
      * @returns Element's textContent.
      */
-    textContent(options?: TimeoutOptions & StrictnessOptions): string;
+    textContent(options?: TimeoutOptions): string;
 
     /**
      * Returns `input.value` for the selected `input`, `textarea` or `select` element.
      * @param options Options to use.
      * @returns The input value of the element.
      */
-    inputValue(options?: TimeoutOptions & StrictnessOptions): string;
+    inputValue(options?: TimeoutOptions): string;
 
     /**
      * Select one or more options which match the values. If the select has the multiple attribute, all matching options are selected,
@@ -1762,7 +1762,7 @@ export interface Locator {
      */
     selectOption(
         values: string | string[] | { value?: string; label?: string; index?: number },
-        options?: ElementHandleOptions & StrictnessOptions,
+        options?: ElementHandleOptions,
     ): string[];
 
     /**
@@ -1784,13 +1784,13 @@ export interface Locator {
      * Hover over the element.
      * @param options Options to use.
      */
-    hover(options?: MouseMoveOptions & StrictnessOptions): void;
+    hover(options?: MouseMoveOptions): void;
 
     /**
      * Tap on the chosen element.
      * @param options Options to use.
      */
-    tap(options?: MouseMoveOptions & StrictnessOptions): void;
+    tap(options?: MouseMoveOptions): void;
 
     /**
      * Dispatches HTML DOM event types e.g. `click`.
@@ -1798,13 +1798,13 @@ export interface Locator {
      * @param eventInit Event-specific properties.
      * @param options Options to use.
      */
-    dispatchEvent(type: string, eventInit?: EvaluationArgument, options?: TimeoutOptions & StrictnessOptions): void;
+    dispatchEvent(type: string, eventInit?: EvaluationArgument, options?: TimeoutOptions): void;
 
     /**
      * Wait for the element to be in a particular state e.g. `visible`.
      * @param options Wait options.
      */
-    waitFor(options?: { state?: ElementState } & TimeoutOptions & StrictnessOptions): void;
+    waitFor(options?: { state?: ElementState } & TimeoutOptions): void;
 }
 
 /**

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -915,8 +915,6 @@ locator.click({ position: { x: 0, y: 0 } });
 locator.click({ timeout: 10000 });
 // $ExpectType Promise<void>
 locator.click({ trial: true });
-// $ExpectType Promise<void>
-locator.click({ strict: true });
 
 // $ExpectType void
 locator.dblclick();
@@ -940,8 +938,6 @@ locator.dblclick({ position: { x: 0, y: 0 } });
 locator.dblclick({ timeout: 10000 });
 // $ExpectType void
 locator.dblclick({ trial: true });
-// $ExpectType void
-locator.dblclick({ strict: true });
 
 // $ExpectType void
 locator.check();
@@ -955,8 +951,6 @@ locator.check({ position: { x: 0, y: 0 } });
 locator.check({ timeout: 10000 });
 // $ExpectType void
 locator.check({ trial: true });
-// $ExpectType void
-locator.check({ strict: true });
 
 // $ExpectType void
 locator.uncheck();
@@ -970,29 +964,21 @@ locator.uncheck({ position: { x: 0, y: 0 } });
 locator.uncheck({ timeout: 10000 });
 // $ExpectType void
 locator.uncheck({ trial: true });
-// $ExpectType void
-locator.uncheck({ strict: true });
 
 // $ExpectType boolean
 locator.isChecked();
 // $ExpectType boolean
 locator.isChecked({ timeout: 10000 });
-// $ExpectType boolean
-locator.isChecked({ strict: true });
 
 // $ExpectType boolean
 locator.isEnabled();
 // $ExpectType boolean
 locator.isEnabled({ timeout: 10000 });
-// $ExpectType boolean
-locator.isEnabled({ strict: true });
 
 // $ExpectType boolean
 locator.isDisabled();
 // $ExpectType boolean
 locator.isDisabled({ timeout: 10000 });
-// $ExpectType boolean
-locator.isDisabled({ strict: true });
 
 // $ExpectType boolean
 locator.isVisible();
@@ -1010,15 +996,11 @@ locator.fill("text", { force: true });
 locator.fill("text", { noWaitAfter: true });
 // $ExpectType void
 locator.fill("text", { timeout: 10000 });
-// $ExpectType void
-locator.fill("text", { strict: true });
 
 // $ExpectType void
 locator.focus();
 // $ExpectType void
 locator.focus({ timeout: 10000 });
-// $ExpectType void
-locator.focus({ strict: true });
 
 // @ts-expect-error
 locator.getAttribute();
@@ -1026,36 +1008,26 @@ locator.getAttribute();
 locator.getAttribute("attr");
 // $ExpectType string | null
 locator.getAttribute("attr", { timeout: 10000 });
-// $ExpectType string | null
-locator.getAttribute("attr", { strict: true });
 
 // $ExpectType string
 locator.innerHTML();
 // $ExpectType string
 locator.innerHTML({ timeout: 10000 });
-// $ExpectType string
-locator.innerHTML({ strict: true });
 
 // $ExpectType string
 locator.innerText();
 // $ExpectType string
 locator.innerText({ timeout: 10000 });
-// $ExpectType string
-locator.innerText({ strict: true });
 
 // $ExpectType string
 locator.textContent();
 // $ExpectType string
 locator.textContent({ timeout: 10000 });
-// $ExpectType string
-locator.textContent({ strict: true });
 
 // $ExpectType string
 locator.inputValue();
 // $ExpectType string
 locator.inputValue({ timeout: 10000 });
-// $ExpectType string
-locator.inputValue({ strict: true });
 
 // @ts-expect-error
 locator.selectOption();
@@ -1077,8 +1049,6 @@ locator.selectOption("value", { force: true });
 locator.selectOption("value", { noWaitAfter: true });
 // $ExpectType string[]
 locator.selectOption("value", { timeout: 10000 });
-// $ExpectType string[]
-locator.selectOption("value", { strict: true });
 
 // @ts-expect-error
 locator.type();
@@ -1107,8 +1077,6 @@ locator.hover({ position: { x: 0, y: 0 } });
 locator.hover({ timeout: 10000 });
 // $ExpectType void
 locator.hover({ trial: true });
-// $ExpectType void
-locator.hover({ strict: true });
 
 // $ExpectType void
 locator.tap();
@@ -1122,8 +1090,6 @@ locator.tap({ position: { x: 0, y: 0 } });
 locator.tap({ timeout: 10000 });
 // $ExpectType void
 locator.tap({ trial: true });
-// $ExpectType void
-locator.tap({ strict: true });
 
 // @ts-expect-error
 locator.dispatchEvent();
@@ -1134,7 +1100,7 @@ locator.dispatchEvent("click", { buttons: 2 & 4 });
 // $ExpectType void
 locator.dispatchEvent("click", { buttons: 2 & 4 }, { timeout: 10000 });
 // $ExpectType void
-locator.dispatchEvent("click", { buttons: 2 & 4 }, { strict: true });
+locator.dispatchEvent("click", { buttons: 2 & 4 });
 
 // $ExpectType void
 locator.waitFor();
@@ -1144,8 +1110,6 @@ for (const state of ["attached", "detached", "visible", "hidden"]) {
 }
 // $ExpectType void
 locator.waitFor({ timeout: 10000 });
-// $ExpectType void
-locator.waitFor({ strict: true });
 
 //
 // JSHandle


### PR DESCRIPTION
The strict option was added accidentally into the type definitions when they were originally created for the locator API. It has never been accepted when working with the locator API.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: NA
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.