### PR TITLE
Add setInputFiles to k6 browser module

### DIFF
--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1149,26 +1149,26 @@ export interface ElementHandle extends JSHandle {
     selectText(options?: ElementHandleOptions): void;
 
     /**
-     * Sets the value of the file input to these files.
+     * Sets the file input element's value to the specified files.
      *
-     * To work with local file on the file system, work with the experimental
-     * fs module to load and read the file's content.
+     * To work with local files on the file system, use the experimental
+     * fs module to load and read the file contents.
      *
-     * The elementHandle must an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+     * The {@link ElementHandle | element handle} must be an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
      * @param files
      * @param options
      */
     setInputFiles(files: File | File[], options?: {
         /**
          * Maximum time in milliseconds. Pass 0 to disable the timeout. Default
-         * is overridden by the setDefaultTimeout option on `BrowserContext` or
-         * `Page`. Defaults to 30000.
+         * is overridden by the setDefaultTimeout option on {@link BrowserContext} or
+         * {@link Page}. Defaults to 30000.
          */
         timeout?: number;
 
         /**
          * If set to `true` and a navigation occurs from performing this action, it
-         * will not wait for it to complete. Defaults to `false`.
+         * does not wait for it to complete. Defaults to `false`.
          */
         noWaitAfter?: boolean;
     }): void;
@@ -1522,12 +1522,12 @@ export interface Frame {
     isVisible(selector: string, options?: StrictnessOptions): boolean;
 
     /**
-     * Sets the value of the file input to these files.
+     * Sets the file input element's value to the specified files.
      *
-     * To work with local file on the file system, work with the experimental
-     * fs module to load and read the file's content.
+     * To work with local files on the file system, use the experimental
+     * fs module to load and read the file contents.
      *
-     * This method expects `selector` to point to an
+     * This method expects a `selector` to point to an
      * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
      * @param selector A selector to search for an element. If there are multiple
      * elements satisfying the selector, the first will be used.
@@ -1537,8 +1537,8 @@ export interface Frame {
     setInputFiles(selector: string, files: File | File[], options?: {
         /**
          * Maximum time in milliseconds. Pass 0 to disable the timeout. Default
-         * is overridden by the setDefaultTimeout option on `BrowserContext` or
-         * `Page`. Defaults to 30000.
+         * is overridden by the setDefaultTimeout option on {@link BrowserContext} or
+         * {@link Page}. Defaults to 30000.
          */
         timeout?: number;
 
@@ -2985,12 +2985,13 @@ export interface Page {
     setExtraHTTPHeaders(headers: { [key: string]: string }): void;
 
     /**
-     * Sets the value of the file input to these files.
+     * Sets the file input element's value to the specified files.
      *
-     * To work with local file on the file system, work with the experimental
-     * fs module to load and read the file's content.
+     * To work with local files on the file system, use the experimental
+     * fs module to load and read the file contents.
      *
-     * This method expects `selector` to point to an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+     * This method expects a `selector` to point to an
+     * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
      * @param selector A selector to search for an element. If there are multiple
      * elements satisfying the selector, the first will be used.
      * @param files
@@ -2999,8 +3000,8 @@ export interface Page {
     setInputFiles(selector: string, files: File | File[], options?: {
         /**
          * Maximum time in milliseconds. Pass 0 to disable the timeout. Default
-         * is overridden by the setDefaultTimeout option on `BrowserContext` or
-         * `Page`. Defaults to 30000.
+         * is overridden by the setDefaultTimeout option on {@link BrowserContext} or
+         * {@link Page}. Defaults to 30000.
          */
         timeout?: number;
 

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -2985,6 +2985,33 @@ export interface Page {
     setExtraHTTPHeaders(headers: { [key: string]: string }): void;
 
     /**
+     * Sets the value of the file input to these files.
+     *
+     * To work with local file on the file system, work with the experimental
+     * fs module to load and read the file's content.
+     *
+     * This method expects `selector` to point to an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+     * @param selector A selector to search for an element. If there are multiple
+     * elements satisfying the selector, the first will be used.
+     * @param files
+     * @param options
+     */
+    setInputFiles(selector: string, files: File | File[], options?: {
+        /**
+         * Maximum time in milliseconds. Pass 0 to disable the timeout. Default
+         * is overridden by the setDefaultTimeout option on `BrowserContext` or
+         * `Page`. Defaults to 30000.
+         */
+        timeout?: number;
+
+        /**
+         * If set to `true` and a navigation occurs from performing this action, it
+         * will not wait for it to complete. Defaults to `false`.
+         */
+        noWaitAfter?: boolean;
+    }): void;
+
+    /**
      * This will update the page's width and height.
      *
      * @param viewportSize

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -1522,6 +1522,34 @@ export interface Frame {
     isVisible(selector: string, options?: StrictnessOptions): boolean;
 
     /**
+     * Sets the value of the file input to these files.
+     *
+     * To work with local file on the file system, work with the experimental
+     * fs module to load and read the file's content.
+     *
+     * This method expects `selector` to point to an
+     * [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+     * @param selector A selector to search for an element. If there are multiple
+     * elements satisfying the selector, the first will be used.
+     * @param files
+     * @param options
+     */
+    setInputFiles(selector: string, files: File | File[], options?: {
+        /**
+         * Maximum time in milliseconds. Pass 0 to disable the timeout. Default
+         * is overridden by the setDefaultTimeout option on `BrowserContext` or
+         * `Page`. Defaults to 30000.
+         */
+        timeout?: number;
+
+        /**
+         * If set to `true` and a navigation occurs from performing this action, it
+         * will not wait for it to complete. Defaults to `false`.
+         */
+        noWaitAfter?: boolean;
+    }): void;
+
+    /**
      * Wait for the given function to return a truthy value.
      * @param predicate The function to call and wait for.
      * @param options The options to use.

--- a/types/k6/experimental/browser.d.ts
+++ b/types/k6/experimental/browser.d.ts
@@ -115,6 +115,23 @@ export interface EventSequenceOptions {
     delay?: number;
 }
 
+export interface File {
+    /**
+     * File name
+     */
+    name: string;
+
+    /**
+     * File type
+     */
+    mimeType: string;
+
+    /**
+     * File content
+     */
+    buffer: ArrayBuffer;
+}
+
 export type ElementHandleOptions = {
     /**
      * Setting this to `true` will bypass the actionability checks (visible,
@@ -1130,6 +1147,31 @@ export interface ElementHandle extends JSHandle {
      * @param options Element handle options.
      */
     selectText(options?: ElementHandleOptions): void;
+
+    /**
+     * Sets the value of the file input to these files.
+     *
+     * To work with local file on the file system, work with the experimental
+     * fs module to load and read the file's content.
+     *
+     * The elementHandle must an [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
+     * @param files
+     * @param options
+     */
+    setInputFiles(files: File | File[], options?: {
+        /**
+         * Maximum time in milliseconds. Pass 0 to disable the timeout. Default
+         * is overridden by the setDefaultTimeout option on `BrowserContext` or
+         * `Page`. Defaults to 30000.
+         */
+        timeout?: number;
+
+        /**
+         * If set to `true` and a navigation occurs from performing this action, it
+         * will not wait for it to complete. Defaults to `false`.
+         */
+        noWaitAfter?: boolean;
+    }): void;
 
     /**
      * Scrolls element into view if needed, and then uses `page.tapscreen` to tap in the center of the element

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -654,6 +654,8 @@ page.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain", buffer: ne
 // $ExpectType void
 page.setInputFiles("foo", [{ name: "file1.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) },
                                     { name: "file2.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }]);
+// $ExpectType void
+page.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }, { noWaitAfter: true, timeout: 1000 });
 
 // @ts-expect-error
 page.setViewportSize();
@@ -1449,6 +1451,8 @@ elementHandle.setInputFiles({ name: "file.txt", mimeType: "text/plain", buffer: 
 // $ExpectType void
 elementHandle.setInputFiles([{ name: "file1.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) },
                              { name: "file2.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }]);
+// $ExpectType void
+elementHandle.setInputFiles({ name: "file.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }, { noWaitAfter: true, timeout: 1000 });
 
 // $ExpectType void
 elementHandle.tap();
@@ -1935,6 +1939,8 @@ frame.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain", buffer: n
 // $ExpectType void
 frame.setInputFiles("foo", [{ name: "file1.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) },
                                     { name: "file2.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }]);
+// $ExpectType void
+frame.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }, { noWaitAfter: true, timeout: 1000 });
 
 // @ts-expect-error
 frame.waitForFunction();

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -1905,6 +1905,22 @@ frame.isVisible("input");
 frame.isVisible("input", { strict: true });
 
 // @ts-expect-error
+frame.setInputFiles();
+// @ts-expect-error
+frame.setInputFiles("foo");
+// @ts-expect-error
+frame.setInputFiles("foo", {});
+// @ts-expect-error
+frame.setInputFiles("foo", { name: "file.txt" });
+// @ts-expect-error
+frame.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain" });
+// $ExpectType void
+frame.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) });
+// $ExpectType void
+frame.setInputFiles("foo", [{ name: "file1.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) },
+                                    { name: "file2.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }]);
+
+// @ts-expect-error
 frame.waitForFunction();
 // $ExpectType Promise<JSHandle<boolean>>
 frame.waitForFunction(() => true);

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -640,6 +640,22 @@ page.setExtraHTTPHeaders();
 page.setExtraHTTPHeaders({ Accept: "text/html" });
 
 // @ts-expect-error
+page.setInputFiles();
+// @ts-expect-error
+page.setInputFiles("foo");
+// @ts-expect-error
+page.setInputFiles("foo", {});
+// @ts-expect-error
+page.setInputFiles("foo", { name: "file.txt" });
+// @ts-expect-error
+page.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain" });
+// $ExpectType void
+page.setInputFiles("foo", { name: "file.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) });
+// $ExpectType void
+page.setInputFiles("foo", [{ name: "file1.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) },
+                                    { name: "file2.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }]);
+
+// @ts-expect-error
 page.setViewportSize();
 // $ExpectType void
 page.setViewportSize({ width: 800, height: 600 });

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -1420,6 +1420,20 @@ elementHandle.selectText({ force: true });
 // $ExpectType void
 elementHandle.selectText({ noWaitAfter: true });
 
+// @ts-expect-error
+elementHandle.setInputFiles();
+// @ts-expect-error
+elementHandle.setInputFiles({});
+// @ts-expect-error
+elementHandle.setInputFiles({ name: "file.txt" });
+// @ts-expect-error
+elementHandle.setInputFiles({ name: "file.txt", mimeType: "text/plain" });
+// $ExpectType void
+elementHandle.setInputFiles({ name: "file.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) });
+// $ExpectType void
+elementHandle.setInputFiles([{ name: "file1.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) },
+                             { name: "file2.txt", mimeType: "text/plain", buffer: new ArrayBuffer(0) }]);
+
 // $ExpectType void
 elementHandle.tap();
 // $ExpectType void


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

If adding a new definition:

- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an npm package, match the name. If not, do not conflict with the name of an npm package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] Represents shape of module/library [correctly](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html)
- [ ] `tsconfig.json` [should have](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#tsconfigjson) `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.