### PR TITLE
Fix `ResponseBody` type to use `ArrayBuffer` instead of `bytes`

### DIFF
--- a/types/k6/http.d.ts
+++ b/types/k6/http.d.ts
@@ -620,7 +620,7 @@ export interface RefinedResponse<RT extends ResponseType | undefined> extends Re
 /**
  * Response body.
  */
-export type ResponseBody = string | bytes | null;
+export type ResponseBody = string | ArrayBuffer | null;
 
 /**
  * Refined response body.
@@ -628,7 +628,7 @@ export type ResponseBody = string | bytes | null;
  * @template RT - `Params.responseType` value.
  * @privateRemarks Default type is a union due to depending on program options.
  */
-export type RefinedResponseBody<RT extends ResponseType | undefined> = RT extends "binary" ? bytes
+export type RefinedResponseBody<RT extends ResponseType | undefined> = RT extends "binary" ? ArrayBuffer
     : RT extends "none" ? null
     : RT extends "text" ? string
     : RT extends undefined ? string | null

--- a/types/k6/k6-tests.ts
+++ b/types/k6/k6-tests.ts
@@ -59,6 +59,14 @@ function test6() {
     http.get("https://loadimpact.com/features");
 }
 
+function test7() {
+    const res = http.get("https://httpbin.test.k6.io/bytes/10", { responseType: "binary" });
+    check(res, {
+        "response code was 200": res => res.status === 200,
+        "body size was 1234 bytes": res => res.body.byteLength === 1234,
+    });
+}
+
 function httpTest1() {
     const responses = http.batch([
         "http://test.loadimpact.com",

--- a/types/k6/test/http.ts
+++ b/types/k6/test/http.ts
@@ -213,6 +213,13 @@ asyncRequest("get", addressFromHttpURL);
 asyncRequest("get", address).then(res => {
     responseDefault = res;
 });
+asyncRequest("get", address, null, { responseType: "binary" }).then(res => {
+    responseBinary = res;
+});
+asyncRequest("get", address, null, { responseType: "binary" }).then(res => {
+    // @ts-expect-error
+    responseDefault = res;
+});
 // @ts-expect-error
 asyncRequest("post", address, 5);
 asyncRequest("post", address, "welcome to the internet").then(res => {


### PR DESCRIPTION
This matches the behavior of v0.51 of k6.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] [Run `pnpm test k6`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/grafana/k6/blob/33d3caa7d1b6825873d6b1c98f1d5cbbb467dc9f/js/modules/k6/http/request.go#L134
