### PR TITLE
Add type defs for `page.getBy*` API for k6 browser

### DIFF
--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2836,6 +2836,32 @@ export interface Page {
     ): Locator;
 
     /**
+     * Returns {@link Locator} to the element with the corresponding placeholder text.
+     *
+     * @example
+     * ```js
+     * const locator = page.getByPlaceholder('name@example.com');
+     *
+     * await locator.fill('my.name@example.com');
+     * ```
+     *
+     * @param placeholder The placeholder text of the element.
+     * @param options Options to use.
+     * @returns The locator to the element with the corresponding placeholder text.
+     */
+    getByPlaceholder(
+        placeholder: string | RegExp,
+        options?: {
+            /**
+             * Whether the locator should be exact.
+             *
+             * @defaultValue false
+             */
+            exact?: boolean;
+        }
+    ): Locator;
+
+    /**
      * Navigates to the specified url and returns the main resource response.
      *
      * navigating to `about:blank` or navigation to the same URL with a different

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2716,6 +2716,75 @@ export interface Page {
     ): Promise<string | null>;
 
     /**
+     * Returns {@link Locator} to the element with the corresponding role.
+     *
+     * @example
+     * ```js
+     * const locator = page.getByRole('button', { name: 'Pizza, Please!' });
+     * 
+     * await locator.click();
+     * ```
+     *
+     * @param role The role of the element.
+     * @param options Options to use.
+     * @returns The locator to the element with the corresponding role.
+     */
+    getByRole(
+        role: "alert" | "alertdialog" | "application" | "article" | "banner" | "blockquote" | "button" | "caption" | "cell" | "checkbox" | "code" | "columnheader" | "combobox" | "complementary" | "contentinfo" | "definition" | "dialog" | "directory" | "document" | "emphasis" | "feed" | "figure" | "form" | "generic" | "grid" | "gridcell" | "group" | "heading" | "img" | "insertion" | "link" | "list" | "listbox" | "listitem" | "log" | "main" | "marquee" | "math" | "menu" | "menubar" | "menuitem" | "menuitemcheckbox" | "menuitemradio" | "meter" | "navigation" | "none" | "note" | "option" | "presentation" | "progressbar" | "radio" | "radiogroup" | "region" | "row" | "rowgroup" | "rowheader" | "scrollbar" | "search" | "searchbox" | "separator" | "slider" | "spinbutton" | "status" | "strong" | "subscript" | "superscript" | "switch" | "tab" | "table" | "tablist" | "tabpanel" | "term" | "textbox" | "time" | "timer" | "toolbar" | "tooltip" | "tree" | "treegrid" | "treeitem",
+        options?: {
+            /**
+             * Whether the accessible `options.name` should be checked exactly for equality.
+             *
+             * @defaultValue false
+             */
+            exact?: boolean;
+
+            /**
+             * Whether to include elements that are normally excluded from the accessibility tree.
+             *
+             * @defaultValue false
+             */
+            includeHidden?: boolean;
+
+            /**
+             * A number attribute that is traditionally used for headings h1-h6.
+             */
+            level?: number;
+
+            /**
+             * An accessible name for the element, such as a text in a button or a label for an input.
+             */
+            name?: string | RegExp;
+
+            /**
+             * A boolean attribute that can be used to indicate if a checkbox is checked or not.
+             */
+            checked?: boolean;
+
+            /**
+             * A boolean attribute that can be used to indicate if an element is disabled or not.
+             */
+            disabled?: boolean;
+
+            /**
+             * A boolean attribute that can be used to indicate if an element is expanded or not.
+             */
+            expanded?: boolean;
+
+            /**
+             * A boolean attribute that can be used to indicate if an element is pressed or not.
+             */
+            pressed?: boolean;
+
+            /**
+             * A boolean attribute that can be used to indicate if an element is selected or not.
+             */
+            selected?: boolean;
+        }
+    ): Locator;
+
+
+    /**
      * Navigates to the specified url and returns the main resource response.
      *
      * navigating to `about:blank` or navigation to the same URL with a different

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2836,6 +2836,28 @@ export interface Page {
     ): Locator;
 
     /**
+     * Returns {@link Locator} to the element with the corresponding test ID.
+     * Note that this method only supports the `data-testid` attribute.
+     *
+     * @example
+     * HTML:
+     * ```html
+     * <button data-testid="submit-button">Submit</button>
+     * ```
+     *
+     * JavaScript:
+     * ```js
+     * const locator = page.getByTestId('submit-button');
+     *
+     * await locator.click();
+     * ```
+     *
+     * @param testId The test ID of the element.
+     * @returns The locator to the element with the corresponding test ID.
+     */
+    getByTestId(testId: string | RegExp): Locator;
+
+    /**
      * Returns {@link Locator} to the element with the corresponding placeholder text.
      *
      * @example

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2810,6 +2810,32 @@ export interface Page {
     ): Locator;
 
     /**
+     * Returns {@link Locator} to the element with the corresponding label text.
+     *
+     * @example
+     * ```js
+     * const locator = page.getByLabel('Password');
+     *
+     * await locator.fill('my-password');
+     * ```
+     *
+     * @param label The label text of the element.
+     * @param options Options to use.
+     * @returns The locator to the element with the corresponding label text.
+     */
+    getByLabel(
+        label: string | RegExp,
+        options?: {
+            /**
+             * Whether the locator should be exact.
+             *
+             * @defaultValue false
+             */
+            exact?: boolean;
+        }
+    ): Locator;
+
+    /**
      * Navigates to the specified url and returns the main resource response.
      *
      * navigating to `about:blank` or navigation to the same URL with a different

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2862,6 +2862,32 @@ export interface Page {
     ): Locator;
 
     /**
+     * Returns {@link Locator} to the element with the corresponding title text.
+     *
+     * @example
+     * ```js
+     * const locator = page.getByTitle('Information box');
+     *
+     * await locator.click();
+     * ```
+     *
+     * @param title The title text of the element.
+     * @param options Options to use.
+     * @returns The locator to the element with the corresponding title text.
+     */
+    getByTitle(
+        title: string | RegExp,
+        options?: {
+            /**
+             * Whether the locator should be exact.
+             *
+             * @defaultValue false
+             */
+            exact?: boolean;
+        }
+    ): Locator;
+
+    /**
      * Navigates to the specified url and returns the main resource response.
      *
      * navigating to `about:blank` or navigation to the same URL with a different

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2836,6 +2836,62 @@ export interface Page {
     ): Locator;
 
     /**
+     * Allows locating elements by their text content. Returns {@link Locator}.
+     *
+     * Consider the following DOM structure:
+     *
+     * ```html
+     * <div>Hello <span>world</span></div>
+     * <div>Hello</div>
+     * ```
+     *
+     * You can locate by text substring, exact string, or a regular expression:
+     *
+     * @example
+     * ```js
+     * // Matches <span>
+     * page.getByText('world');
+     *
+     * // Matches first <div>
+     * page.getByText('Hello world');
+     *
+     * // Matches second <div>
+     * page.getByText('Hello', { exact: true });
+     *
+     * // Matches both <div>s
+     * page.getByText(/Hello/);
+     *
+     * // Matches second <div>
+     * page.getByText(/^hello$/i);
+     * ```
+     *
+     * Matching by text always normalizes whitespace, even with exact match. For
+     * example, it turns multiple spaces into one, turns line breaks into spaces
+     * and ignores leading and trailing whitespace.
+     *
+     * Input elements of the type `button` and `submit` are matched by their
+     * `value` instead of the text content. For example, locating by text
+     * `"Log in"` matches `<input type=button value="Log in">`.
+     *
+     * @param text Text to locate the element by.
+     * @param options Options to use.
+     * @returns The locator to the element with the corresponding text content.
+     */
+    getByText(
+        text: string | RegExp,
+        options?: {
+            /**
+             * Whether to find an exact match: case-sensitive and whole-string.
+             * Default to false. Ignored when locating by a regular expression.
+             * Note that exact match still trims whitespace.
+             *
+             * @defaultValue false
+             */
+            exact?: boolean;
+        }
+    ): Locator;
+
+    /**
      * Returns {@link Locator} to the element with the corresponding test ID.
      * Note that this method only supports the `data-testid` attribute.
      *

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -2783,6 +2783,31 @@ export interface Page {
         }
     ): Locator;
 
+    /**
+     * Returns {@link Locator} to the element with the corresponding alt text.
+     *
+     * @example
+     * ```js
+     * const locator = page.getByAltText('pizza');
+     *
+     * await locator.click();
+     * ```
+     *
+     * @param altText The alt text of the element.
+     * @param options Options to use.
+     * @returns The locator to the element with the corresponding alt text.
+     */
+    getByAltText(
+        altText: string | RegExp,
+        options?: {
+            /**
+             * Whether the locator should be exact.
+             *
+             * @defaultValue false
+             */
+            exact?: boolean;
+        }
+    ): Locator;
 
     /**
      * Navigates to the specified url and returns the main resource response.

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -1377,6 +1377,19 @@ export interface ElementHandle extends JSHandle {
 
     /**
      * Select one or more options of a `<select>` element which match the values.
+     *
+     * @example
+     * ```js
+     * // Single selection matching the value or label
+     * handle.selectOption('blue');
+     *
+     * // single selection matching the label
+     * handle.selectOption({ label: 'Blue' });
+     *
+     * // multiple selection
+     * handle.selectOption(['red', 'green', 'blue']);
+     * ```
+     *
      * @param values Values of options to select.
      * @param options Element handle options.
      * @returns List of selected options.
@@ -1567,6 +1580,19 @@ export interface Frame {
     /**
      * Select the given options and return the array of option values of the first element
      * found that matches the selector.
+     *
+     * @example
+     * ```js
+     * // Single selection matching the value or label
+     * frame.selectOption('blue');
+     *
+     * // single selection matching the label
+     * frame.selectOption({ label: 'Blue' });
+     *
+     * // multiple selection
+     * frame.selectOption(['red', 'green', 'blue']);
+     * ```
+     *
      * @param selector The selector to use.
      * @param values The values to select.
      * @returns The array of option values of the first element found.
@@ -2164,6 +2190,19 @@ export interface Locator {
     /**
      * Select one or more options which match the values. If the select has the multiple attribute, all matching options are selected,
      * otherwise only the first option matching one of the passed options is selected.
+     *
+     * @example
+     * ```js
+     * // Single selection matching the value or label
+     * locator.selectOption('blue');
+     *
+     * // single selection matching the label
+     * locator.selectOption({ label: 'Blue' });
+     *
+     * // multiple selection
+     * locator.selectOption(['red', 'green', 'blue']);
+     * ```
+     *
      * @param values Values of options to select.
      * @param options Options to use.
      * @returns List of selected options.
@@ -3547,6 +3586,18 @@ export interface Page {
      *
      * This select one or more options which match the values from a <select>
      * element.
+     *
+     * @example
+     * ```js
+     * // Single selection matching the value or label
+     * page.selectOption('#colors-options', 'blue');
+     *
+     * // single selection matching the label
+     * page.selectOption('#colors-options', { label: 'Blue' });
+     *
+     * // multiple selection
+     * page.selectOption('#colors-options', ['red', 'green', 'blue']);
+     * ```
      *
      * @param selector A selector to search for an element. If there are multiple
      * elements satisfying the selector, the first will be used.

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -673,6 +673,31 @@ async function test() {
     // $ExpectType Promise<void>
     page.press(selector, "a", { timeout: 10000 });
 
+    // $ExpectType Locator
+    page.getByRole('button', { name: 'Sign in' });
+    // $ExpectType Locator
+    page.getByRole('button', { name: /Sign in/i });
+    // $ExpectType Locator
+    page.getByRole('button', { exact: true });
+    // $ExpectType Locator
+    page.getByRole('checkbox', { checked: true });
+    // $ExpectType Locator
+    page.getByRole('checkbox', { disabled: true });
+    // $ExpectType Locator
+    page.getByRole('checkbox', { expanded: true });
+    // $ExpectType Locator
+    page.getByRole('checkbox', { includeHidden: true });
+    // $ExpectType Locator
+    page.getByRole('heading', { level: 1 });
+    // $ExpectType Locator
+    page.getByRole('checkbox', { pressed: true });
+    // $ExpectType Locator
+    page.getByRole('checkbox', { selected: true });
+    // @ts-expect-error
+    page.getByRole('button', { name: 123 });
+    // @ts-expect-error
+    page.getByRole('invalid-role');
+
     // $ExpectType Promise<Response | null>
     page.reload();
     // $ExpectType Promise<Response | null>

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -1155,6 +1155,9 @@ async function test() {
     // $ExpectType Promise<void>
     locator.fill("text", { timeout: 10000 });
 
+    // $ExpectType Locator
+    locator.first();
+
     // $ExpectType Promise<void>
     locator.focus();
     // $ExpectType Promise<void>
@@ -1176,6 +1179,16 @@ async function test() {
     locator.innerText();
     // $ExpectType Promise<string>
     locator.innerText({ timeout: 10000 });
+
+    // $ExpectType Locator
+    locator.last();
+
+    // $ExpectType Locator
+    locator.nth(0);
+    // @ts-expect-error
+    locator.nth();
+    // @ts-expect-error
+    locator.nth("0");
 
     // $ExpectType Promise<string | null>
     locator.textContent();

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -698,6 +698,17 @@ async function test() {
     // @ts-expect-error
     page.getByRole('invalid-role');
 
+    // $ExpectType Locator
+    page.getByAltText('pizza');
+    // $ExpectType Locator
+    page.getByAltText(/pizza/i);
+    // @ts-expect-error
+    page.getByAltText(123);
+    // $ExpectType Locator
+    page.getByAltText('pizza', { exact: true });
+    // @ts-expect-error
+    page.getByAltText('pizza', { exact: 'true' });
+
     // $ExpectType Promise<Response | null>
     page.reload();
     // $ExpectType Promise<Response | null>

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -720,6 +720,17 @@ async function test() {
     // @ts-expect-error
     page.getByLabel('Password', { exact: 'true' });
 
+    // $ExpectType Locator
+    page.getByPlaceholder('name@example.com');
+    // $ExpectType Locator
+    page.getByPlaceholder(/name@example.com/i);
+    // @ts-expect-error
+    page.getByPlaceholder(123);
+    // $ExpectType Locator
+    page.getByPlaceholder('name@example.com', { exact: true });
+    // @ts-expect-error
+    page.getByPlaceholder('name@example.com', { exact: 'true' });
+
     // $ExpectType Promise<Response | null>
     page.reload();
     // $ExpectType Promise<Response | null>

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -721,6 +721,17 @@ async function test() {
     page.getByLabel('Password', { exact: 'true' });
 
     // $ExpectType Locator
+    page.getByTitle('Information box');
+    // $ExpectType Locator
+    page.getByTitle(/Information box/i);
+    // @ts-expect-error
+    page.getByTitle(123);
+    // $ExpectType Locator
+    page.getByTitle('Information box', { exact: true });
+    // @ts-expect-error
+    page.getByTitle('Information box', { exact: 'true' });
+
+    // $ExpectType Locator
     page.getByPlaceholder('name@example.com');
     // $ExpectType Locator
     page.getByPlaceholder(/name@example.com/i);

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -589,6 +589,72 @@ async function test() {
         });
     });
 
+    // $ExpectType void
+    page.on("request", request => {
+        // $ExpectType Promise<Record<string, string>>
+        request.allHeaders();
+        // $ExpectType Frame
+        request.frame();
+        // $ExpectType Record<string, string>
+        request.headers();
+        // $ExpectType Promise<{ name: string; value: string; }[]>
+        request.headersArray();
+        // $ExpectType Promise<string | null>
+        request.headerValue("content-type");
+        // $ExpectType boolean
+        request.isNavigationRequest();
+        // $ExpectType string
+        request.method();
+        // $ExpectType string | null
+        request.postData();
+        // $ExpectType ArrayBuffer | null
+        request.postDataBuffer();
+        // $ExpectType ResourceType
+        request.resourceType();
+        // $ExpectType Promise<Response | null>
+        request.response();
+        // $ExpectType Promise<{ body: number; headers: number; }>
+        request.size();
+        // $ExpectType ResourceTiming
+        request.timing();
+    });
+
+    // $ExpectType void
+    page.on("response", response => {
+        // $ExpectType Promise<Record<string, string>>
+        response.allHeaders();
+        // $ExpectType Promise<ArrayBuffer>
+        response.body();
+        // $ExpectType Frame
+        response.frame();
+        // $ExpectType Record<string, string>
+        response.headers();
+        // $ExpectType Promise<{ name: string; value: string; }[]>
+        response.headersArray();
+        // $ExpectType Promise<string | null>
+        response.headerValue("content-type");
+        // $ExpectType Promise<string[]>
+        response.headerValues("content-type");
+        // $ExpectType Promise<any>
+        response.json();
+        // $ExpectType boolean
+        response.ok();
+        // $ExpectType Request
+        response.request();
+        // $ExpectType Promise<SecurityDetailsObject | null>
+        response.securityDetails();
+        // $ExpectType Promise<{ ipAddress: string; port: number; } | null>
+        response.serverAddr();
+        // $ExpectType number
+        response.status();
+        // $ExpectType string
+        response.statusText();
+        // $ExpectType Promise<{ body: number; headers: number; }>
+        response.size();
+        // $ExpectType string
+        response.url();
+    });
+
     // $ExpectType Promise<Page | null>
     page.opener();
 

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -709,6 +709,17 @@ async function test() {
     // @ts-expect-error
     page.getByAltText('pizza', { exact: 'true' });
 
+    // $ExpectType Locator
+    page.getByLabel('Password');
+    // $ExpectType Locator
+    page.getByLabel(/Password/i);
+    // @ts-expect-error
+    page.getByLabel(123);
+    // $ExpectType Locator
+    page.getByLabel('Password', { exact: true });
+    // @ts-expect-error
+    page.getByLabel('Password', { exact: 'true' });
+
     // $ExpectType Promise<Response | null>
     page.reload();
     // $ExpectType Promise<Response | null>

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -721,6 +721,13 @@ async function test() {
     page.getByLabel('Password', { exact: 'true' });
 
     // $ExpectType Locator
+    page.getByTestId('submit-button');
+    // $ExpectType Locator
+    page.getByTestId(/submit-button/i);
+    // @ts-expect-error
+    page.getByTestId(123);
+
+    // $ExpectType Locator
     page.getByTitle('Information box');
     // $ExpectType Locator
     page.getByTitle(/Information box/i);

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -721,6 +721,17 @@ async function test() {
     page.getByLabel('Password', { exact: 'true' });
 
     // $ExpectType Locator
+    page.getByText('Welcome');
+    // $ExpectType Locator
+    page.getByText(/Welcome/i);
+    // @ts-expect-error
+    page.getByText(123);
+    // $ExpectType Locator
+    page.getByText('Welcome', { exact: true });
+    // @ts-expect-error
+    page.getByText('Welcome', { exact: 'true' });
+
+    // $ExpectType Locator
     page.getByTestId('submit-button');
     // $ExpectType Locator
     page.getByTestId(/submit-button/i);


### PR DESCRIPTION
Add type defs for `page.getBy*` API for k6 browser. It includes:

* `page.getByRole`
* `page.getByAltText`
* `page.getByLabel`
* `page.getByPlaceholder`
* `page.getByTitle`
* `page.getByTestId`
* `page.getByText`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

https://github.com/grafana/k6/pull/4843
https://github.com/grafana/k6/pull/4881
https://github.com/grafana/k6/pull/4890
https://github.com/grafana/k6/pull/4904
https://github.com/grafana/k6/pull/4910
https://github.com/grafana/k6/pull/4911
https://github.com/grafana/k6/pull/4912