### PR TITLE
Add `waitForURL` to `frame` and `page` in k6 browser

### DIFF
--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -1877,6 +1877,49 @@ export interface Frame {
     }): Promise<Response | null>;
 
     /**
+     * Waits for the page to navigate to the specified URL.
+     *
+     * @example
+     * ```js
+     * await page.locator('a[href="/login"]').click();
+     * await page.waitForURL(/.*\/login$/);
+     * ```
+     *
+     * @param url An exact match or regular expression to match the URL.
+     * @param options Options to use.
+     */
+    waitForURL(
+        url: string | RegExp,
+        options?: {
+            /**
+             * Maximum operation time in milliseconds. Defaults to `30` seconds.
+             * The default value can be changed via the
+             * browserContext.setDefaultNavigationTimeout(timeout),
+             * browserContext.setDefaultTimeout(timeout),
+             * page.setDefaultNavigationTimeout(timeout) or
+             * page.setDefaultTimeout(timeout) methods.
+             *
+             * Setting the value to `0` will disable the timeout.
+             */
+            timeout?: number;
+
+            /**
+             * When to consider operation succeeded, defaults to `load`. Events can be
+             * either:
+             * - `'domcontentloaded'` - consider operation to be finished when the
+             * `DOMContentLoaded` event is fired.
+             * - `'load'` - consider operation to be finished when the `load` event is
+             * fired.
+             * - `'networkidle'` - **DISCOURAGED** consider operation to be finished
+             * when there are no network connections for at least `500` ms. Don't use
+             * this method for testing especially with chatty websites where the event
+             * may never fire, rely on web assertions to assess readiness instead.
+             */
+            waitUntil?: "load" | "domcontentloaded" | "networkidle";
+        }
+    ): Promise<void>;
+
+    /**
      * Wait for the given selector to match the waiting criteria.
      * @param selector The selector to use.
      * @param options The options to use.
@@ -3866,6 +3909,49 @@ export interface Page {
          */
         waitUntil?: "load" | "domcontentloaded" | "networkidle";
     }): Promise<Response | null>;
+
+    /**
+     * Waits for the page to navigate to the specified URL.
+     *
+     * @example
+     * ```js
+     * await page.locator('a[href="/login"]').click();
+     * await page.waitForURL(/.*\/login$/);
+     * ```
+     *
+     * @param url An exact match or regular expression to match the URL.
+     * @param options Options to use.
+     */
+    waitForURL(
+        url: string | RegExp,
+        options?: {
+            /**
+             * Maximum operation time in milliseconds. Defaults to `30` seconds.
+             * The default value can be changed via the
+             * browserContext.setDefaultNavigationTimeout(timeout),
+             * browserContext.setDefaultTimeout(timeout),
+             * page.setDefaultNavigationTimeout(timeout) or
+             * page.setDefaultTimeout(timeout) methods.
+             *
+             * Setting the value to `0` will disable the timeout.
+             */
+            timeout?: number;
+
+            /**
+             * When to consider operation succeeded, defaults to `load`. Events can be
+             * either:
+             * - `'domcontentloaded'` - consider operation to be finished when the
+             * `DOMContentLoaded` event is fired.
+             * - `'load'` - consider operation to be finished when the `load` event is
+             * fired.
+             * - `'networkidle'` - **DISCOURAGED** consider operation to be finished
+             * when there are no network connections for at least `500` ms. Don't use
+             * this method for testing especially with chatty websites where the event
+             * may never fire, rely on web assertions to assess readiness instead.
+             */
+            waitUntil?: "load" | "domcontentloaded" | "networkidle";
+        }
+    ): Promise<void>;
 
     /**
      * **NOTE** Use web assertions that assert visibility or a locator-based

--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -1841,7 +1841,40 @@ export interface Frame {
      * @param options The options to use.
      * @returns A promise that resolves to the response of the navigation when it happens.
      */
-    waitForNavigation(options?: ContentLoadOptions): Promise<Response | null>;
+    waitForNavigation(options?: {
+        /**
+         * Maximum operation time in milliseconds. Defaults to `30` seconds. The
+         * default value can be changed via the
+         * browserContext.setDefaultNavigationTimeout(timeout),
+         * browserContext.setDefaultTimeout(timeout),
+         * page.setDefaultNavigationTimeout(timeout) or
+         * page.setDefaultTimeout(timeout) methods.
+         *
+         * Setting the value to `0` will disable the timeout.
+         */
+        timeout?: number;
+
+        /**
+         * An exact string or regex pattern to match while waiting for the
+         * navigation. Note that if the parameter is a string, the method will
+         * wait for navigation to URL that is exactly equal to the string.
+         */
+        url?: string|RegExp;
+
+        /**
+         * When to consider operation succeeded, defaults to `load`. Events can be
+         * either:
+         * - `'domcontentloaded'` - consider operation to be finished when the
+         * `DOMContentLoaded` event is fired.
+         * - `'load'` - consider operation to be finished when the `load` event is
+         * fired.
+         * - `'networkidle'` - **DISCOURAGED** consider operation to be finished
+         * when there are no network connections for at least `500` ms. Don't use
+         * this method for testing especially with chatty websites where the event
+         * may never fire, rely on web assertions to assess readiness instead.
+         */
+        waitUntil?: "load" | "domcontentloaded" | "networkidle";
+    }): Promise<Response | null>;
 
     /**
      * Wait for the given selector to match the waiting criteria.
@@ -3811,6 +3844,13 @@ export interface Page {
          * Setting the value to `0` will disable the timeout.
          */
         timeout?: number;
+
+        /**
+         * An exact string or regex pattern to match while waiting for the
+         * navigation. Note that if the parameter is a string, the method will
+         * wait for navigation to URL that is exactly equal to the string.
+         */
+        url?: string|RegExp;
 
         /**
          * When to consider operation succeeded, defaults to `load`. Events can be

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -852,6 +852,10 @@ async function test() {
     page.waitForNavigation({ waitUntil: "domcontentloaded" });
     // $ExpectType Promise<Response | null>
     page.waitForNavigation({ waitUntil: "networkidle" });
+    // $ExpectType Promise<Response | null>
+    page.waitForNavigation({ url: "https://example.com" });
+    // $ExpectType Promise<Response | null>
+    page.waitForNavigation({ url: /.*\/api\/pizza$/ });
 
     // @ts-expect-error
     page.waitForSelector();
@@ -2185,6 +2189,10 @@ async function test() {
     frame.waitForNavigation({ timeout: 10000 });
     // $ExpectType Promise<Response | null>
     frame.waitForNavigation({ waitUntil: "domcontentloaded" });
+    // $ExpectType Promise<Response | null>
+    frame.waitForNavigation({ url: "https://example.com" });
+    // $ExpectType Promise<Response | null>
+    frame.waitForNavigation({ url: /.*\/api\/pizza$/ });
 
     // @ts-expect-error
     frame.waitForSelector();

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -858,6 +858,17 @@ async function test() {
     page.waitForNavigation({ url: /.*\/api\/pizza$/ });
 
     // @ts-expect-error
+    page.waitForURL();
+    // $ExpectType Promise<void>
+    page.waitForURL("https://example.com");
+    // $ExpectType Promise<void>
+    page.waitForURL(/.*\/api\/pizza$/);
+    // $ExpectType Promise<void>
+    page.waitForURL("https://example.com", { timeout: 10000 });
+    // $ExpectType Promise<void>
+    page.waitForURL("https://example.com", { waitUntil: "domcontentloaded" });
+
+    // @ts-expect-error
     page.waitForSelector();
     // $ExpectType Promise<ElementHandle>
     page.waitForSelector(selector);
@@ -2193,6 +2204,17 @@ async function test() {
     frame.waitForNavigation({ url: "https://example.com" });
     // $ExpectType Promise<Response | null>
     frame.waitForNavigation({ url: /.*\/api\/pizza$/ });
+
+    // @ts-expect-error
+    frame.waitForURL();
+    // $ExpectType Promise<void>
+    frame.waitForURL("https://example.com");
+    // $ExpectType Promise<void>
+    frame.waitForURL(/.*\/api\/pizza$/);
+    // $ExpectType Promise<void>
+    frame.waitForURL("https://example.com", { timeout: 10000 });
+    // $ExpectType Promise<void>
+    frame.waitForURL("https://example.com", { waitUntil: "domcontentloaded" });
 
     // @ts-expect-error
     frame.waitForSelector();


### PR DESCRIPTION
This adds:

* `url` option to `waitForNavigation`.
* `waitForURL` to `frame` and `page`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `pnpm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the `package.json`.

https://github.com/grafana/k6/pull/4917
https://github.com/grafana/k6/pull/4920