### PR TITLE
add TypeScript definitions for page.goBack() and page.goForward()

### DIFF
--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -4991,6 +4991,37 @@ export interface Page {
     }): Promise<Response | null>;
 
     /**
+     * Goes back to the previous page in the history.
+     *
+     * @example
+     * ```js
+     * await page.goto('https://example.com');
+     * await page.goto('https://example.com/page2');
+     * await page.goBack(); // Will navigate back to the first page
+     * ```
+     *
+     * @param options Navigation options.
+     * @returns A promise that resolves to the response of the requested navigation when it happens.
+     * Returns null if there is no previous entry in the history.
+     */
+    goBack(options?: NavigationOptions): Promise<Response | null>;
+
+    /**
+     * Goes forward to the next page in the history.
+     *
+     * @example
+     * ```js
+     * await page.goBack(); // Navigate back first
+     * await page.goForward(); // Then navigate forward
+     * ```
+     *
+     * @param options Navigation options.
+     * @returns A promise that resolves to the response of the requested navigation when it happens.
+     * Returns null if there is no next entry in the history.
+     */
+    goForward(options?: NavigationOptions): Promise<Response | null>;
+
+    /**
      * Adds a route to the page to modify network requests made by that page.
      *
      * Once routing is enabled, every request matching the url pattern will stall unless it's continued, fulfilled or aborted.

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -782,6 +782,24 @@ async function test() {
     // $ExpectType Promise<Response | null>
     page.reload({ waitUntil: "domcontentloaded" });
 
+    // $ExpectType Promise<Response | null>
+    page.goBack();
+    // $ExpectType Promise<Response | null>
+    page.goBack({ timeout: 10000 });
+    // $ExpectType Promise<Response | null>
+    page.goBack({ waitUntil: "domcontentloaded" });
+    // $ExpectType Promise<Response | null>
+    page.goBack({ timeout: 10000, waitUntil: "load" });
+
+    // $ExpectType Promise<Response | null>
+    page.goForward();
+    // $ExpectType Promise<Response | null>
+    page.goForward({ timeout: 10000 });
+    // $ExpectType Promise<Response | null>
+    page.goForward({ waitUntil: "domcontentloaded" });
+    // $ExpectType Promise<Response | null>
+    page.goForward({ timeout: 10000, waitUntil: "load" });
+
     // $ExpectType Promise<ArrayBuffer>
     page.screenshot();
     // $ExpectType Promise<ArrayBuffer>


### PR DESCRIPTION
PR: https://github.com/grafana/k6/pull/5494
Issue: https://github.com/grafana/k6/issues/5400