### PR TITLE
Add page.on('requestfinished') event handler type definitions

### DIFF
--- a/types/k6/browser/index.d.ts
+++ b/types/k6/browser/index.d.ts
@@ -4910,6 +4910,21 @@ export interface Page {
     on(event: "requestfailed", listener: (request: Request) => void): void;
 
     /**
+     * Registers a handler function to listen for network requests that
+     * successfully complete (receive a response). The handler will receive an
+     * instance of {@link Request}, which includes information about the request.
+     *
+     * **Usage**
+     *
+     * ```js
+     * page.on('requestfinished', request => {
+     *   console.log(`Request finished: ${request.method()} ${request.url()}`);
+     * });
+     * ```
+     */
+    on(event: "requestfinished", listener: (request: Request) => void): void;
+
+    /**
      * Returns the page that opened the current page. The first page that is
      * navigated to will have a null opener.
      */

--- a/types/k6/test/browser.ts
+++ b/types/k6/test/browser.ts
@@ -702,6 +702,36 @@ async function test() {
         request.failure();
     });
 
+    // $ExpectType void
+    page.on("requestfinished", request => {
+        // $ExpectType Promise<Record<string, string>>
+        request.allHeaders();
+        // $ExpectType Frame
+        request.frame();
+        // $ExpectType Record<string, string>
+        request.headers();
+        // $ExpectType Promise<{ name: string; value: string; }[]>
+        request.headersArray();
+        // $ExpectType Promise<string | null>
+        request.headerValue("content-type");
+        // $ExpectType boolean
+        request.isNavigationRequest();
+        // $ExpectType string
+        request.method();
+        // $ExpectType string | null
+        request.postData();
+        // $ExpectType ArrayBuffer | null
+        request.postDataBuffer();
+        // $ExpectType ResourceType
+        request.resourceType();
+        // $ExpectType Promise<Response | null>
+        request.response();
+        // $ExpectType Promise<{ body: number; headers: number; }>
+        request.size();
+        // $ExpectType ResourceTiming
+        request.timing();
+    });
+
     // $ExpectType Promise<Page | null>
     page.opener();
 


### PR DESCRIPTION
It extends https://github.com/grafana/k6-DefinitelyTyped/pull/111 to resolve the conflict